### PR TITLE
Fix for annotation deletion request not receiving the proper success …

### DIFF
--- a/src/services/db/entities.ts
+++ b/src/services/db/entities.ts
@@ -228,7 +228,7 @@ const removeEntityFromCollection = async (req: Request<IEntityRequestParams>, re
 
   const message = `Deleted ${coll} ${req.params.identifier}`;
   Logger.info(message);
-  res.status(200).send(message);
+  res.status(200).send({message});
 
   return RepoCache.flush();
 };


### PR DESCRIPTION
When issuing an annotation deletion request in the Viewer it is properly executed but the returned object is just a string (message). That triggers a JSON parse error since an object is expected and leads to the Viewer considering the deletion failed.