### PR TITLE
Fix API /get/groups not responding

### DIFF
--- a/src/routes/api-v1.ts
+++ b/src/routes/api-v1.ts
@@ -55,7 +55,7 @@ router.get(['/get/ldata', '/auth'], Users.getCurrentUserData);
 router.get('/get/users', Users.getStrippedUsers);
 
 // Get a list of all groups
-router.get('/get/groups', (_, res) => Repo.group.findAll().then(res.json));
+router.get('/get/groups', (_, res) => Repo.group.findAll().then(groups => res.json(groups)));
 
 // Add or update a document to a collection
 router.post('/post/push/:collection', Users.isAllowedToEdit, Entities.addEntityToCollection);


### PR DESCRIPTION
The API route `/get/groups` which is used in [AddCompilationWizard](https://github.com/Kompakkt/Repo/blob/0ef183d9ab9ac402c0048f96580d85b9b5ba67fa/src/app/wizards/add-compilation/add-compilation-wizard.component.ts#L88) and [EntitySettingsDialog](https://github.com/Kompakkt/Repo/blob/d0cf72d11702b1e71f061abb52091cddc3c3bc1d/src/app/dialogs/entity-settings-dialog/entity-settings-dialog.component.ts#L39) of [Kompakkt/Repo](https://github.com/Kompakkt/Repo/) failed to respond to requests.

This PR fixes the route.