### PR TITLE
Add migration for finishing draft entities with correct metadata

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,10 +20,12 @@ import { ensureDefaultUserProfile } from './jobs/ensure-default-user-profile';
 import { ensureEntityCreatorIsProfile } from './jobs/ensure-entity-creator-is-profile';
 import { ensureDefaultPasswordStrategy } from './jobs/ensure-default-password-strategy';
 import { migrateCreatorAndAccessFields } from './jobs/migrate-creator-and-access-fields';
+import { migrateFinishedDraftEntities } from './jobs/migrate-finished-draft-entities';
 
 const jobs = {
   migrateUserProfiles,
   migrateCreatorAndAccessFields,
+  migrateFinishedDraftEntities,
   cleanupPersons,
   decreatePopularityTimer,
   ensureDefaultPasswordStrategy,

--- a/src/jobs/migrate-finished-draft-entities.ts
+++ b/src/jobs/migrate-finished-draft-entities.ts
@@ -1,0 +1,90 @@
+import {
+  digitalEntityCollection,
+  entityCollection,
+  migrationCollection,
+  Migrations,
+  userCollection,
+} from 'src/mongo';
+import { ObjectId } from 'mongodb';
+import { Collection, isDigitalEntity, isEntity } from '@kompakkt/common';
+import { saveHandler } from 'src/routers/modules/api.v1/save-to-collection';
+
+/**
+ * This migration handles a bugged case, where some entities have been uploaded as draft, edited later, but were never marked as "finished".
+ * This resulted in entities with incorrect "name" field values on the entities, while the digital entity itself has correct metadata.
+ */
+export const migrateFinishedDraftEntities = async () => {
+  const result = await migrationCollection.findOne({
+    name: Migrations.migrateFinishedDraftEntities,
+  });
+  if (result) return;
+
+  const updatedList = new Array<string>();
+  try {
+    const cursor = entityCollection.aggregate([
+      {
+        $addFields: {
+          digitalEntityId: { $toObjectId: '$relatedDigitalEntity._id' },
+        },
+      },
+      {
+        $lookup: {
+          from: digitalEntityCollection.collectionName,
+          localField: 'digitalEntityId',
+          foreignField: '_id',
+          as: 'digitalEntityDoc',
+        },
+      },
+      {
+        $unwind: '$digitalEntityDoc',
+      },
+    ]);
+    for await (const entity of cursor) {
+      const digitalEntity = entity.digitalEntityDoc;
+      if (!isDigitalEntity(digitalEntity)) continue;
+      if (!isEntity(entity)) continue;
+      // If the entity has the same name, it is likely that it was not affected by the bug
+      if (entity.name === digitalEntity.title) continue;
+
+      const updatedEntity = {
+        ...entity,
+        name: digitalEntity.title.trim(),
+        finished: true,
+      };
+
+      // Remove the fields added for the lookup
+      delete (updatedEntity as any).digitalEntityDoc;
+      delete (updatedEntity as any).digitalEntityId;
+
+      const userdata = await userCollection.findOne({
+        _id: new ObjectId(entity.creator._id),
+      });
+      if (!userdata) {
+        throw new Error(`User with _id: ${entity.creator._id} not found`);
+      }
+
+      const success = await saveHandler({
+        collection: Collection.entity,
+        body: updatedEntity,
+        userdata,
+      });
+
+      if (!success) {
+        throw new Error(`Failed to update entity with _id: ${entity._id}`);
+      }
+      updatedList.push(entity._id.toString());
+    }
+
+    await migrationCollection.insertOne({
+      name: Migrations.migrateFinishedDraftEntities,
+      completedAt: Date.now(),
+    });
+
+    console.log(
+      `Migration of finished draft entities completed. Updated ${updatedList.length} entities.`,
+      updatedList.join(', '),
+    );
+  } catch (err) {
+    console.error('Error during migration of finished draft entities:', err);
+  }
+};

--- a/src/mongo.ts
+++ b/src/mongo.ts
@@ -82,6 +82,7 @@ export const followsCollection = accountsDb.collection<{
 export enum Migrations {
   migrateCreatorAndAccessFields = 'migrateCreatorAndAccessFields',
   migrateUserProfiles = 'migrateUserProfiles',
+  migrateFinishedDraftEntities = 'migrateFinishedDraftEntities',
 }
 export const migrationCollection = accountsDb.collection<{
   name: Migrations;

--- a/src/routers/modules/api.v1/save-to-collection.ts
+++ b/src/routers/modules/api.v1/save-to-collection.ts
@@ -120,10 +120,12 @@ const transformEntity: TransformFn<IEntity> = async (body, user) => {
       })
     : undefined;
 
+  const name = (digitalEntity?.title ?? asEntity.name ?? `Temp-${asEntity._id?.toString()}`).trim();
+
   return {
     __hits: asEntity.__hits ?? 0,
     __createdAt: asEntity.__createdAt ?? new ObjectId(asEntity._id).getTimestamp().getTime(),
-    __normalizedName: asEntity.name?.trim().toLowerCase() ?? '',
+    __normalizedName: name.toLowerCase(),
     __annotationCount: Object.keys(asEntity.annotations || {}).length,
     __downloadable: asEntity.__downloadable ?? asEntity.options?.allowDownload ?? false,
     __licenses:
@@ -138,7 +140,7 @@ const transformEntity: TransformFn<IEntity> = async (body, user) => {
     files: asEntity.files,
     finished: asEntity.finished,
     mediaType: asEntity.mediaType,
-    name: asEntity.name,
+    name: name,
     online: asEntity.online,
     processed: asEntity.processed,
     relatedDigitalEntity: flattenDocument({


### PR DESCRIPTION
In addition to bug fixes in the Repo (https://github.com/Kompakkt/Repo/pull/225) this PR retroactively fixes entities that were bugged with a migration.