### PR TITLE
Fix video preview generation permissions

### DIFF
--- a/src/routers/modules/utility/utility.ts
+++ b/src/routers/modules/utility/utility.ts
@@ -83,11 +83,13 @@ export const countEntityUses = async (
   }
   filter[`entities.${identifier.toString()}`] = { $exists: true };
 
-  const result = await compilationCollection.find(filter).toArray();
-  const compilations = result.map(compilation => ({
-    ...compilation,
-    password: !!compilation.password,
-  }));
+  const compilations = await compilationCollection
+    .find(filter)
+    .toArray()
+    .catch(err => {
+      log('Error counting entity uses', err, filter);
+      return [];
+    });
   const occurences = compilations.length;
 
   return { occurences, compilations };


### PR DESCRIPTION
This route was not protected, allowing anyone to (theoretically) submit
screenshots for a new video preview. It now shares the same system as
general entity settings, meaning only the Owner, Editors and Kompakkt
Admins can generate them.