### PR TITLE
Fix utility countEntityUses

### DIFF
--- a/src/routers/modules/utility/utility.ts
+++ b/src/routers/modules/utility/utility.ts
@@ -31,21 +31,10 @@ const userInAccessQuery = async (user: ServerDocument<IUserData>) => {
   return query;
 };
 
-export const countEntityUses = async (
-  identifier: string | ObjectId,
-  userdata?: ServerDocument<IUserData>,
-) => {
-  // Build query for:
-  // (user is creator || user is whitelisted) && has entity
-  const filter: Filter<ServerDocument<ICompilation>> = {};
-  if (userdata) {
-    filter.$or ??= [];
-    filter.$or.push({
-      'creator._id': { $in: asIdQueryArray(userdata._id) },
-    });
-    filter.$or.push(await userInAccessQuery(userdata));
-  }
-  filter[`entities.${identifier.toString()}`] = { $exists: true };
+export const countEntityUses = async (identifier: string | ObjectId) => {
+  const filter: Filter<ServerDocument<ICompilation>> = {
+    [`entities.${identifier.toString()}`]: { $exists: true },
+  };
 
   const compilations = await compilationCollection
     .find(filter)

--- a/src/routers/utility.router.ts
+++ b/src/routers/utility.router.ts
@@ -13,15 +13,9 @@ import { Collection, EntityAccessRole, UserRank } from '@kompakkt/common';
 const utilityRouter = new Elysia().use(configServer).group('/utility', app =>
   app
     .use(authService)
-    .get(
-      '/countentityuses/:id',
-      async ({ params: { id }, userdata }) => countEntityUses(id, userdata),
-      {
-        params: t.Object({
-          id: t.String(),
-        }),
-      },
-    )
+    .get('/countentityuses/:id', async ({ params: { id } }) => countEntityUses(id), {
+      params: t.Object({ id: t.String() }),
+    })
     .post(
       '/generate-entity-video-preview',
       async ({ body: { entityId, screenshots }, status, userdata }) => {


### PR DESCRIPTION
Its only used in places where the occurences should be public
information, hence no reason for linking it explicitly to user data