### PR TITLE
Fix: ensure-upload-structure args & onError return path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,10 +122,9 @@ PluginController.routers$.subscribe(async routerConfigs => {
         } else {
           console.log('We got a validation error', Bun.inspect(error.messageValue, { depth: 2 }));
         }
-      } else {
-        err(`Error on ${path}:`, error);
-        return status(500, { error: 'Internal Server Error' });
       }
+      err(`Error on ${path}:`, error);
+      return status(500, { error: 'Internal Server Error' });
     })
     .use(app)
     .use(finalServer)

--- a/src/jobs/ensure-upload-structure.ts
+++ b/src/jobs/ensure-upload-structure.ts
@@ -18,7 +18,7 @@ export const ensureUploadStructure = async () => {
   if (allExist.every(d => d)) return true;
   info('Ensuring upload structure');
   try {
-    await Promise.all(directories.map(ensure));
+    await Promise.all(directories.map(directory => ensure(directory, false)));
   } catch (e) {
     err('Failed ensuring upload structure', e);
     return false;


### PR DESCRIPTION
Two small bug fixes.

### src/jobs/ensure-upload-structure.ts
directories.map(ensure) passed the array index as the 2nd arg of ensure(dir, recursive?), so the recursive flag was truthy for every entry after index 0. Now explicitly passes false.

### src/index.ts
onError had an if (validation) { ... } else { return 500 } shape that left a non-returning path, tripping TS's not all code paths return a value. Flattened to a single err(...) + return status(500, ...) after the validation branch.