### PR TITLE
Return value even on validation error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,6 +121,7 @@ PluginController.routers$.subscribe(async routerConfigs => {
           }
         } else {
           console.log('We got a validation error', Bun.inspect(error.messageValue, { depth: 2 }));
+          return status(200, error.value);
         }
       }
       err(`Error on ${path}:`, error);


### PR DESCRIPTION
Not all schemas fully work yet, so returning the intended response is better than not returning anything.